### PR TITLE
Annotated 태그 사용에 대한 설명 수정

### DIFF
--- a/book/02-git-basics/sections/tagging.asc
+++ b/book/02-git-basics/sections/tagging.asc
@@ -84,7 +84,7 @@ It's generally recommended that you create annotated tags so you can have all th
 //////////////////////////
 한편 Annotated 태그는 Git 데이터베이스에 태그를 만든 사람의 이름, 이메일과 태그를 만든 날짜, 그리고 태그 메시지도 저장한다.
 GPG(GNU Privacy Guard)로 서명할 수도 있다.
-이 모든 정보를 저장해둬야 할 때만 Annotated 태그를 추천한다. 그냥 다른 정보를 저장하지 않는 단순한 태그가 필요하다면 Lightweight 태그를 사용하는 것이 좋다.
+일반적으로 Annotated 태그를 만들어 이 모든 정보를 사용할 수 있도록 하는 것이 좋다. 하지만 임시로 생성하는 태그거나 이러한 정보를 유지할 필요가 없는 경우에는 Lightweight 태그를 사용할 수도 있다.
 
 [[_annotated_tags]]
 //////////////////////////


### PR DESCRIPTION
원문에는 Annotated 태그 사용을 `권장`하고 있습니다. 번역판에서는 꼭 필요한 경우에만 Annotated 를 사용하라고 가이드 합니다. 해당 부분 수정하여 반영합니다.

### 변경 전

이 모든 정보를 저장해둬야 **할 때만** Annotated 태그를 추천한다.

### 변경 후

일반적으로 Annotated 태그를 만들어 이 모든 정보를 사용할 수 있도록 하는 것이 좋다.