### PR TITLE
한국어판에서 서문이 나오지 않는 문제 수정

### DIFF
--- a/progit.asc
+++ b/progit.asc
@@ -6,6 +6,8 @@ Pro Git
 :toclevels: 2
 :front-cover-image: image:book/cover.png[width=1050,height=1600]
 
+inlcude::book/preface.asc[]
+
 include::book/01-introduction/1-introduction.asc[]
 
 include::book/02-git-basics/1-git-basics.asc[]
@@ -31,4 +33,3 @@ include::book/A-git-in-other-environments/1-git-other-environments.asc[]
 include::book/B-embedding-git/1-embedding-git.asc[]
 
 include::book/C-git-commands/1-git-commands.asc[]
-

--- a/progit.asc
+++ b/progit.asc
@@ -6,7 +6,7 @@ Pro Git
 :toclevels: 2
 :front-cover-image: image:book/cover.png[width=1050,height=1600]
 
-inlcude::book/preface.asc[]
+include::book/preface.asc[]
 
 include::book/01-introduction/1-introduction.asc[]
 


### PR DESCRIPTION
빌드했을 때 원본과 비교하여 한국어판에서는 서문이 나오지 않고 바로 본문으로 시작하는것이 이상하여 확인해보니

https://github.com/progit/progit2/commit/c4ccfb8d533b864a206fd06ae1835c7143691c55

https://github.com/progit/progit2/commit/de2f821db04934e8fc303cdadf52647a3e3a0d64

두 커밋이 누락되어있는게 원인으로 판단되어서 cherry pick 하였습니다.

첫번쨰 커밋은 파일 두개를 수정한 커밋인데 충돌을 해결하기 애매하여 progit.asc 에 해당하는 변경만 반영했습니다.

프로젝트의 규칙과 맞는지 모르겠습니다. 

