### PR TITLE
improve translation

### DIFF
--- a/book/10-git-internals/sections/objects.asc
+++ b/book/10-git-internals/sections/objects.asc
@@ -53,7 +53,7 @@ The output from the command is a 40-character checksum hash.
 This is the SHA-1 hash – a checksum of the content you're storing plus a header, which you'll learn about in a bit.
 Now you can see how Git has stored your data:
 //////////////////////////
-이 명령은 표준입력으로 들어오는 데이터를 저장할 수 있다. `-w` 옵션을 줘야 실제로 저장한다. `-w`가 없으면 저장하지 않고 key만 보여준다.
+이 명령은 표준입력으로 들어오는 데이터를 저장할 수 있다. `-w` 옵션을 줘야 실제로 저장한다. `-w` 가 없으면 저장하지 않고 key만 보여준다.
 그리고 `--stdin` 옵션을 주면 표준입력으로 입력되는 데이터를 읽는다. 이 옵션이 없으면 파일 경로를 알려줘야 한다.
 `hash-object` 명령이 출력하는 것은 40자 길이의 체크섬 해시다.
 이 해시는 헤더 정보와 데이터 모두에 대한 SHA-1 해시이다. 헤더 정보는 차차 자세히 살펴볼 것이다.

--- a/book/10-git-internals/sections/objects.asc
+++ b/book/10-git-internals/sections/objects.asc
@@ -37,7 +37,7 @@ $ find .git/objects -type f
 Git has initialized the `objects` directory and created `pack` and `info` subdirectories in it, but there are no regular files.
 Now, store some text in your Git database:
 //////////////////////////
-아직 빈 디렉토리일 뿐 파일은 아무것도 없다. Git은 `init` 명령으로 저장소를 초기화할 때 `objects` 디렉토리를 만들고 그 밑에 `pack`과 `info` 디렉토리도 만든다.
+아직 빈 디렉토리일 뿐 파일은 아무것도 없다. Git은 `init` 명령으로 저장소를 초기화할 때 `objects` 디렉토리를 만들고 그 밑에 `pack` 과 `info` 디렉토리도 만든다.
 Git 데이터베이스에 텍스트 파일을 저장해보자:
 
 [source,console]

--- a/book/10-git-internals/sections/plumbing-porcelain.asc
+++ b/book/10-git-internals/sections/plumbing-porcelain.asc
@@ -51,7 +51,7 @@ The `description` file is only used by the GitWeb program, so don't worry about 
 The `config` file contains your project-specific configuration options, and the `info` directory keeps a global exclude file (((excludes))) for ignored patterns that you don't want to track in a .gitignore file.
 The `hooks` directory contains your client- or server-side hook scripts, which are discussed in detail in <<_git_hooks>>.
 //////////////////////////
-이 외에 다른 파일들이 더 있지만, 이 상태가 `git init`을 한 직후에 보이는 새 저장소의 모습이다.
+이 외에 다른 파일들이 더 있지만, 이 상태가 `git init` 명령을 실행한 직후에 보이는 새 저장소의 모습이다.
 `description` 파일은 기본적으로 GitWeb 프로그램에서만 사용하기 때문에 이 파일은 신경쓰지 않아도 된다.
 `config` 파일에는 해당 프로젝트에만 적용되는 설정 옵션이 들어 있다. `info` 디렉토리는 .gitignore 파일처럼 무시할 파일의 패턴을 적어 두는 곳이다. 하지만 .gitignore 파일과는 달리 Git으로 관리되지 않는다.
 `hooks` 디렉토리에는 클라이언트 훅이나 서버 훅이 위치한다. 관련 내용은 <<_git_hooks>> 에서 설명한다.


### PR DESCRIPTION
git init가 강조 되도록 수정하였습니다. 
기존의 "git init을 한" 이라는 구문을 "git init 명령을 실행한" 로 수정하였습니다. 다른 문장과 일관되게 보이도록 하였습니다. (31번째 라인)