### PR TITLE
improve translation

### DIFF
--- a/book/10-git-internals/sections/objects.asc
+++ b/book/10-git-internals/sections/objects.asc
@@ -37,7 +37,7 @@ $ find .git/objects -type f
 Git has initialized the `objects` directory and created `pack` and `info` subdirectories in it, but there are no regular files.
 Now, store some text in your Git database:
 //////////////////////////
-아직 빈 디렉토리일 뿐 파일은 아무것도 없다. Git은 `init` 명령으로 저장소를 초기화할 때 `objects` 디렉토리를 만들고 그 밑에 `pack`과 `info` 디렉토리도 만든다.
+아직 빈 디렉토리일 뿐 파일은 아무것도 없다. Git은 `init` 명령으로 저장소를 초기화할 때 `objects` 디렉토리를 만들고 그 밑에 `pack` 과 `info` 디렉토리도 만든다.
 Git 데이터베이스에 텍스트 파일을 저장해보자:
 
 [source,console]
@@ -53,7 +53,7 @@ The output from the command is a 40-character checksum hash.
 This is the SHA-1 hash – a checksum of the content you're storing plus a header, which you'll learn about in a bit.
 Now you can see how Git has stored your data:
 //////////////////////////
-이 명령은 표준입력으로 들어오는 데이터를 저장할 수 있다. `-w` 옵션을 줘야 실제로 저장한다. `-w`가 없으면 저장하지 않고 key만 보여준다.
+이 명령은 표준입력으로 들어오는 데이터를 저장할 수 있다. `-w` 옵션을 줘야 실제로 저장한다. `-w` 가 없으면 저장하지 않고 key만 보여준다.
 그리고 `--stdin` 옵션을 주면 표준입력으로 입력되는 데이터를 읽는다. 이 옵션이 없으면 파일 경로를 알려줘야 한다.
 `hash-object` 명령이 출력하는 것은 40자 길이의 체크섬 해시다.
 이 해시는 헤더 정보와 데이터 모두에 대한 SHA-1 해시이다. 헤더 정보는 차차 자세히 살펴볼 것이다.
@@ -397,7 +397,7 @@ first commit
 //////////////////////////
 The format for a commit object is simple: it specifies the top-level tree for the snapshot of the project at that point; the author/committer information (which uses your `user.name` and `user.email` configuration settings and a timestamp); a blank line, and then the commit message.
 //////////////////////////
-커밋 개체의 형식은 간단하다. 해당 스냅샷에서 최상단 Tree를(역주 - 루트 디렉토리 같은) 하나 가리킨다. 그리고 `user.name`과 `user.email` 설정에서 가져온 Author/Committer 정보, 시간 정보, 그리고 한 라인 띄운 다음 커밋 메시지가 들어간다.
+커밋 개체의 형식은 간단하다. 해당 스냅샷에서 최상단 Tree를(역주 - 루트 디렉토리 같은) 하나 가리킨다. 그리고 `user.name` 과 `user.email` 설정에서 가져온 Author/Committer 정보, 시간 정보, 그리고 한 라인 띄운 다음 커밋 메시지가 들어간다.
 
 //////////////////////////
 Next, you'll write the other two commit objects, each referencing the commit that came directly before it:
@@ -460,7 +460,7 @@ Here are all the objects in the example directory now, commented with what they 
 //////////////////////////
 놀랍지 않은가!
 방금 우리는 고수준 명령어 없이 저수준의 명령으로만 Git 히스토리를 만들었다.
-지금 한 일이 `git add`와 `git commit` 명령을 실행했을 때 Git 내부에서 일어나는 일이다. Git은 변경된 파일을 Blob 개체로 저장하고 현 Index에 따라서 Tree 개체를 만든다. 그리고 이전 커밋 개체와 최상위 Tree 개체를 참고해서 커밋 개체를 만든다.
+지금 한 일이 `git add` 와 `git commit` 명령을 실행했을 때 Git 내부에서 일어나는 일이다. Git은 변경된 파일을 Blob 개체로 저장하고 현 Index에 따라서 Tree 개체를 만든다. 그리고 이전 커밋 개체와 최상위 Tree 개체를 참고해서 커밋 개체를 만든다.
 즉 Blob, Tree, 커밋 개체가 Git의 주요 개체이고 이 개체는 전부 `.git/objects` 디렉토리에 저장된다.
 이 예제에서 생성한 개체는 아래와 같다.
 
@@ -570,7 +570,7 @@ Then, open the file with `File.open()` and write out the previously zlib-compres
 //////////////////////////
 마지막으로 zlib으로 압축한 내용을 개체로 저장한다.
 SHA-1 값 중에서 맨 앞에 있는 두 자를 가져다 하위 디렉토리 이름으로 사용하고 나머지 38자를 그 디렉토리 안에 있는 파일이름으로 사용한다.
-Ruby에서는 `FileUtils.mkdir_p()`로 디렉토리를 (없으면) 만들고 `File.open()`으로 파일을 연다.
+Ruby에서는 `FileUtils.mkdir_p()` 로 디렉토리를 (없으면) 만들고 `File.open()` 으로 파일을 연다.
 그리고 그 파일에 zlib으로 압축한 내용을 `write()` 함수로 저장한다.
 
 [source,console]
@@ -591,5 +591,5 @@ All Git objects are stored the same way, just with different types – instead o
 Also, although the blob content can be nearly anything, the commit and tree content are very specifically formatted.
 //////////////////////////
 다 됐다. 이제 Git Blob 개체를 손으로 만들었다.
-Git 개체는 모두 이 방식으로 저장하며 단지 종류만 다르다. 헤더가 `blob`이 아니라 그냥 `commit`이나 `tree`로 시작하게 되는 것뿐이다.
+Git 개체는 모두 이 방식으로 저장하며 단지 종류만 다르다. 헤더가 `blob` 이 아니라 그냥 `commit` 이나 `tree` 로 시작하게 되는 것뿐이다.
 Blob 개체는 여기서 보여준 것과 거의 같지만 커밋이 개체나 Tree 개체는 각기 다른 형식을 사용한다.

--- a/book/10-git-internals/sections/plumbing-porcelain.asc
+++ b/book/10-git-internals/sections/plumbing-porcelain.asc
@@ -51,7 +51,7 @@ The `description` file is only used by the GitWeb program, so don't worry about 
 The `config` file contains your project-specific configuration options, and the `info` directory keeps a global exclude file (((excludes))) for ignored patterns that you don't want to track in a .gitignore file.
 The `hooks` directory contains your client- or server-side hook scripts, which are discussed in detail in <<_git_hooks>>.
 //////////////////////////
-이 외에 다른 파일들이 더 있지만, 이 상태가 `git init`을 한 직후에 보이는 새 저장소의 모습이다.
+이 외에 다른 파일들이 더 있지만, 이 상태가 `git init` 명령을 실행한 직후에 보이는 새 저장소의 모습이다.
 `description` 파일은 기본적으로 GitWeb 프로그램에서만 사용하기 때문에 이 파일은 신경쓰지 않아도 된다.
 `config` 파일에는 해당 프로젝트에만 적용되는 설정 옵션이 들어 있다. `info` 디렉토리는 .gitignore 파일처럼 무시할 파일의 패턴을 적어 두는 곳이다. 하지만 .gitignore 파일과는 달리 Git으로 관리되지 않는다.
 `hooks` 디렉토리에는 클라이언트 훅이나 서버 훅이 위치한다. 관련 내용은 <<_git_hooks>> 에서 설명한다.


### PR DESCRIPTION
단어들이 정상적으로 강조 되도록 수정하였습니다.
기존의 "git init을 한" 이라는 구문을 "git init 명령을 실행한" 로 수정하였습니다. 다른 문장과 일관되게 보이도록 하였습니다. (31번째 라인과 비교)