### PR TITLE
change some mistranslation in the section 'Rebase When You Rebase' of 3.6 Git Branching - Rebasing

### DIFF
--- a/book/03-git-branching/sections/rebasing.asc
+++ b/book/03-git-branching/sections/rebasing.asc
@@ -385,10 +385,10 @@ For instance, in the previous scenario, if instead of doing a merge when we're a
 * Determine which have not been rewritten into the target branch (just C2 and C3, since C4 is the same patch as C4')
 * Apply those commits to the top of `teamone/master`
 //////////////////////////
-* 현재 브랜치에만 포함된 커밋을 찾는다. (C2, C3, C4, C6, C7)
-* Merge 커밋을 가려낸다. (C2, C3, C4)
-* 이 중 덮어쓰지 않은 커밋들만 골라낸다. (C2, C3. C4는 C4'와 동일한 Patch다)
-* 남은 커밋들만 다시 `teamone/master` 바탕으로 커밋을 쌓는다.
+* 현재 브랜치에만 포함된 커밋을 결정한다. (C2, C3, C4, C6, C7)
+* Merge 커밋이 아닌 것을 결정한다. (C2, C3, C4)
+* 이 중 merge할 브랜치에 덮어쓰이지 않은 커밋들을 결정한다. (C2, C3. C4는 C4’와 동일한 Patch다)
+* 그 커밋들을 teamone/master에 적용한다.
 
 //////////////////////////
 So instead of the result we see in <<_merge_rebase_work>>, we would end up with something more like <<_rebase_rebase_work>>.


### PR DESCRIPTION
해당 원문은 git가 rebase 수행 시에 각 단계에서 **어떤 동작들을 수행하는가**가 아니라 **어떤 결과를 도출하는가**를 설명한 것입니다. 독자의 입장에서도 각 단계의 결과가 무엇인지 설명하는 것이 무슨 동작을 수행하는지 설명하는 것보다 직관적이고, 또 해당 내용을 읽는 목적을 고려했을 때도 합리적인 방법입니다. 그래서 원문에도 find나 select따위의 동사들을 사용하지 않고 determine과 apply 따위의 동사들을 사용한 것입니다.

원문에 `apply`라는 단어가 쓰인 것처럼 번역본에도 `적용`이라는 단어를 써도 의미가 모호하지 않은 이유는 해당 설명이 전적으로 `git rebase` 시 수면 아래에서 git가 하는 작업들을 나열한 것이기 때문입니다.

마지막으로 복수를 단수형으로 치환하는 번역은 피해주셨으면 합니다. 여느 전문적인 문서와 같이 git를 설명하는 해당 문서도 일상생활에 대한 것이 아닌 논리적인 명세이기 때문에 복수형을 단수형으로 써서는 안 됩니다.