### PR TITLE
fix korean fonts for pdf, #114

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 
 gem 'rake', '13.0.3'
-gem 'asciidoctor', '2.0.12'
+gem 'asciidoctor', '2.0.15'
 
 gem 'json', '2.5.1'
 gem 'awesome_print', '1.9.2'
@@ -15,4 +15,4 @@ gem 'coderay', '1.1.3'
 gem 'pygments.rb', '2.2.0'
 gem 'thread_safe', '0.3.6'
 gem 'epubcheck-ruby', '4.2.5.0'
-gem 'html-proofer', '3.18.8'
+gem 'html-proofer', '3.19.0'

--- a/Rakefile
+++ b/Rakefile
@@ -103,7 +103,7 @@ namespace :book do
       check_contrib()
 
       puts 'Converting to PDF... (this one takes a while)'
-      `bundle exec asciidoctor-pdf #{params} -r asciidoctor-pdf-cjk-kai_gen_gothic -a pdf-style=KaiGenGothicKR progit.asc `
+      `bundle exec asciidoctor-pdf #{params} -a scripts=cjk -a pdf-theme=./korean-theme.yml -a pdf-fontsdir=$(ruby -r asciidoctor-pdf-cjk-kai_gen_gothic -e "print File.expand_path '../fonts', (Gem.datadir 'asciidoctor-pdf-cjk-kai_gen_gothic')") progit.asc 2>/dev/null`
       puts ' -- PDF output at progit.pdf'
   end
 

--- a/korean-theme.yml
+++ b/korean-theme.yml
@@ -1,0 +1,32 @@
+extends: default
+font:
+  catalog:
+    merge: true
+    kaiGen-gothic-kr:
+      normal: KaiGenGothicKR-Regular.ttf
+      bold: KaiGenGothicKR-Bold.ttf
+      italic: KaiGenGothicKR-Regular-Italic.ttf
+      bold_italic: KaiGenGothicKR-Bold-Italic.ttf
+    Noto Serif:
+      normal: GEM_FONTS_DIR/notoserif-regular-subset.ttf
+      bold: GEM_FONTS_DIR/notoserif-bold-subset.ttf
+      italic: GEM_FONTS_DIR/notoserif-italic-subset.ttf
+      bold_italic: GEM_FONTS_DIR/notoserif-bold_italic-subset.ttf
+    # M+ 1mn supports ASCII and the circled numbers used for conums
+    M+ 1mn:
+      normal: GEM_FONTS_DIR/mplus1mn-regular-subset.ttf
+      bold: GEM_FONTS_DIR/mplus1mn-bold-subset.ttf
+      italic: GEM_FONTS_DIR/mplus1mn-italic-subset.ttf
+      bold_italic: GEM_FONTS_DIR/mplus1mn-bold_italic-subset.ttf
+  fallbacks:
+  - kaiGen-gothic-kr
+base:
+  font-family: kaiGen-gothic-kr
+heading:
+  font-family: $base-font-family
+abstract:
+  title:
+    font-family: $heading-font-family
+sidebar:
+  title:
+    font-family: $heading-font-family

--- a/progit.asc
+++ b/progit.asc
@@ -1,7 +1,5 @@
-Pro Git
-=======
+= Pro Git
 Scott Chacon; Ben Straub
-$$VERSION$$, $$DATE$$
 :doctype: book
 :docinfo:
 :toc:
@@ -9,8 +7,6 @@ $$VERSION$$, $$DATE$$
 :pagenums:
 :front-cover-image: image:book/cover.png[width=1050,height=1600]
 :icons: font
-
-ifdef::ebook-format[:leveloffset: -1]
 
 include::book/license.asc[]
 


### PR DESCRIPTION
https://intellij-asciidoc-plugin.ahus1.de/docs/users-guide/features/advanced/pdf-non-latin-languages.html 를 참고 해서 수정했고 자세한 내부 사정은 몰라요. --;

`progit.asc`는 warning을 없애려고 수정했습니다. 아직도 warning이 좀 있어요. 현재 issue랑 PR 해결하고 다시 확인해야 할 것 같네요.