### PR TITLE
fix some adoc syntax and http links (solve #121)

### DIFF
--- a/book/02-git-basics/sections/recording-changes.asc
+++ b/book/02-git-basics/sections/recording-changes.asc
@@ -358,11 +358,11 @@ The rules for the patterns you can put in the `.gitignore` file are as follows:
 
 //////////////////////////
 Glob patterns are like simplified regular expressions that shells use.
-An asterisk (`*`) matches zero or more characters; `[abc]` matches any character inside the brackets (in this case a, b, or c); a question mark (`?`) matches a single character; and brackets enclosing characters separated by a hyphen (`[0-9]`) matches any character between them (in this case 0 through 9).
+An asterisk (`\*`) matches zero or more characters; `[abc]` matches any character inside the brackets (in this case a, b, or c); a question mark (`?`) matches a single character; and brackets enclosing characters separated by a hyphen (`[0-9]`) matches any character between them (in this case 0 through 9).
 You can also use two asterisks to match nested directories; `a/**/z` would match `a/z`, `a/b/z`, `a/b/c/z`, and so on.
 //////////////////////////
 Glob 패턴은 정규표현식을 단순하게 만든 것으로 생각하면 되고 보통 쉘에서 많이 사용한다.
-애스터리스크(`*`)는 문자가 하나도 없거나 하나 이상을 의미하고, `[abc]` 는 중괄호 안에 있는 문자 중 하나를 의미한다(그러니까 이 경우에는 a, b, c). 물음표(`?`)는 문자 하나를 말하고, `[0-9]` 처럼 중괄호 안의 캐릭터 사이에 하이픈(`-`)을 사용하면 그 캐릭터 사이에 있는 문자 하나를 말한다.
+애스터리스크(`\*`)는 문자가 하나도 없거나 하나 이상을 의미하고, `[abc]` 는 중괄호 안에 있는 문자 중 하나를 의미한다(그러니까 이 경우에는 a, b, c). 물음표(`?`)는 문자 하나를 말하고, `[0-9]` 처럼 중괄호 안의 캐릭터 사이에 하이픈(`-`)을 사용하면 그 캐릭터 사이에 있는 문자 하나를 말한다.
 애스터리스크 2개를 사용하여 디렉토리 안의 디렉토리 까지 지정할 수 있다. `a/**/z` 패턴은 `a/z`, `a/b/z`, `a/b/c/z` 디렉토리에 사용할 수 있다.
 
 //////////////////////////

--- a/book/04-git-server/sections/gitlab.asc
+++ b/book/04-git-server/sections/gitlab.asc
@@ -86,12 +86,12 @@ image::images/gitlab-menu.png[GitLab 메뉴의 ``Admin area'' 버튼]
 Users in GitLab are accounts that correspond to people.
 User accounts don't have a lot of complexity; mainly it's a collection of personal information attached to login data.
 Each user account comes with a *namespace*, which is a logical grouping of projects that belong to that user.
-If the user +jane+ had a project named +project+, that project's url would be http://server/jane/project[].
+If the user +jane+ had a project named +project+, that project's url would be `http://server/jane/project`.
 //////////////////////////
 GitLab의 사용자 계정은 한 사람당 하나씩 만든다.
 사용자 계정의 내용은 복잡하지 않다. 로그인 데이터에 추가로 개인 정보가 들어있다.
 각 사용자마다 **네임스페이스**가 있다. 네임스페이스는 프로젝트를 묶는 단위이다.
-*jane* 사용자가 **project**라는 프로젝트를 진행 중이라면 프로젝트의 URL은 http://server/jane/project[]가 될 것이다.
+*jane* 사용자가 **project**라는 프로젝트를 진행 중이라면 프로젝트의 URL은 `http://server/jane/project`가 될 것이다.
 
 [[gitlab_users]]
 //////////////////////////
@@ -125,10 +125,10 @@ This is obviously a much more permanent and destructive action, and its uses are
 
 //////////////////////////
 A GitLab group is an assemblage of projects, along with data about how users can access those projects.
-Each group has a project namespace (the same way that users do), so if the group +training+ has a project +materials+, its url would be http://server/training/materials[].
+Each group has a project namespace (the same way that users do), so if the group +training+ has a project +materials+, its url would be `http://server/training/materials`.
 //////////////////////////
 GitLab 그룹은 프로젝트와 누가 어떤 프로젝트에 어떻게 접근할지에 대한 권한 데이터의 모음이다.
-그룹에도 사용자처럼 프로젝트 네임스페이스가 있다. +training+라는 그룹이 +materials+라는 프로젝트를 가지고 있으면 URL은 http://server/training/materials[]가 된다.
+그룹에도 사용자처럼 프로젝트 네임스페이스가 있다. +training+라는 그룹이 +materials+라는 프로젝트를 가지고 있으면 URL은 `http://server/training/materials`가 된다.
 
 [[gitlab_groups]]
 //////////////////////////

--- a/book/06-github/sections/2-contributing.asc
+++ b/book/06-github/sections/2-contributing.asc
@@ -203,9 +203,9 @@ Now if we go back to our fork on GitHub, we can see that GitHub noticed that we 
 Fork 한 내 저장소에 가면 GitHub은 토픽 브랜치가 하나 Push 됐다는 것을 알려주고 원 저장소에 Pull Request를 보낼 수 있는 큰 녹색 버튼을 보여준다.
 
 //////////////////////////
-You can alternatively go to the ``Branches'' page at `https://github.com/<user>/<project>/branches` to locate your branch and open a new Pull Request from there.
+You can alternatively go to the "`Branches`" page at `\https://github.com/<user>/<project>/branches` to locate your branch and open a new Pull Request from there.
 //////////////////////////
-아니면 저장소의 브랜치 페이지로(`https://github.com/<user>/<project>/branches`) 가서 해당 브랜치의 ``New pull request'' 버튼을 이용한다.
+아니면 저장소의 "`브랜치`" 페이지로(`\https://github.com/<user>/<project>/branches`) 가서 해당 브랜치의 "New pull request" 버튼을 이용한다.
 
 //////////////////////////
 .Pull Request button

--- a/book/09-git-and-other-scms/sections/client-svn.asc
+++ b/book/09-git-and-other-scms/sections/client-svn.asc
@@ -135,11 +135,11 @@ Subversion은 한번에 커밋을 하나씩 받아서 Push 하기 때문에 엄�
 //////////////////////////
 Now that you have a Subversion repository to which you have write access, you can go through a typical workflow.
 You'll start with the `git svn clone` command, which imports an entire Subversion repository into a local Git repository.
-Remember that if you're importing from a real hosted Subversion repository, you should replace the `file:///tmp/test-svn` here with the URL of your Subversion repository:
+Remember that if you're importing from a real hosted Subversion repository, you should replace the `\file:///tmp/test-svn` here with the URL of your Subversion repository:
 //////////////////////////
 이제 갖고 놀 Subversion 저장소를 하나 준비했다.
 `git svn clone` 명령으로 Subversion 저장소 전체를 Git 저장소로 가져온다.
-만약  Subversion 저장소가 로컬에 있는 것이 아니라 리모트 서버에 있으면 `file:///tmp/test-svn` 부분에 서버 저장소의 URL을 적어 준다.
+만약  Subversion 저장소가 로컬에 있는 것이 아니라 리모트 서버에 있으면 `\file:///tmp/test-svn` 부분에 서버 저장소의 URL을 적어 준다.
 
 [source,console]
 ----

--- a/book/10-git-internals/sections/environment.asc
+++ b/book/10-git-internals/sections/environment.asc
@@ -128,12 +128,12 @@ These are used in the `.gitignore` file, but also on the command-line (`git add 
 
 //////////////////////////
 *`GIT_GLOB_PATHSPECS`* and *`GIT_NOGLOB_PATHSPECS`* control the default behavior of wildcards in pathspecs.
-If `GIT_GLOB_PATHSPECS` is set to 1, wildcard characters act as wildcards (which is the default); if `GIT_NOGLOB_PATHSPECS` is set to 1, wildcard characters only match themselves, meaning something like `*.c` would only match a file _named_ ``*.c'', rather than any file whose name ends with `.c`.
-You can override this in individual cases by starting the pathspec with `:(glob)` or `:(literal)`, as in `:(glob)*.c`.
+If `GIT_GLOB_PATHSPECS` is set to 1, wildcard characters act as wildcards (which is the default); if `GIT_NOGLOB_PATHSPECS` is set to 1, wildcard characters only match themselves, meaning something like `\*.c` would only match a file _named_ "`\*.c`", rather than any file whose name ends with `.c`.
+You can override this in individual cases by starting the pathspec with `:(glob)` or `:(literal)`, as in `:(glob)\*.c`.
 //////////////////////////
-`GIT_GLOB_PATHSPECS`, `GIT_NOGLOB_PATHSPECS` 변수로는 Pathspec을 사용할 때 와일드카드 문자로 어떤 동작을 하게 할 지 설정한다.
-`GIT_GLOB_PATHSPECS` 변수의 값을 1로 설정하면 와일드카드 문자는 보통 사용하듯 와일드카드 문자의 역할을 한다(기본값). `GIT_NOGLOB_PATHSPECS` 변수의 값을 1로 설정하면 와일드카드 문자를 진짜 파일 이름의 와일드카드 문자로만 인식한다. `*.c` 라고 하면 진짜 파일 이름이 ``*.c'' 인 파일만 해당하고 확장자가 `.c` 파일은 해당하지 않는다.
-환경 변수에 독립적으로 각 명령에서 이를 선택하여 사용할 때는 `:(glob)` 또는 `:(literal)` 를 명시해서 사용할 수 있다. 예를 들어 `:(glob)*.c` 같이 말이다.
+*`GIT_GLOB_PATHSPECS`*, *`GIT_NOGLOB_PATHSPECS`* 변수로는 Pathspec을 사용할 때 와일드카드 문자로 어떤 동작을 하게 할 지 설정한다.
+`GIT_GLOB_PATHSPECS` 변수의 값을 1로 설정하면 와일드카드 문자는 보통 사용하듯 와일드카드 문자의 역할을 한다(기본값). `GIT_NOGLOB_PATHSPECS` 변수의 값을 1로 설정하면 와일드카드 문자를 진짜 파일 이름의 와일드카드 문자로만 인식한다. `\*.c` 라고 하면 진짜 파일 이름이 "`\*.c`" 인 파일만 해당하고 확장자가 `\*.c` 파일은 해당하지 않는다.
+환경 변수에 독립적으로 각 명령에서 이를 선택하여 사용할 때는 `:(glob)` 또는 `:(literal)` 를 명시해서 사용할 수 있다. 예를 들어 `:(glob)\*.c` 같이 말이다.
 
 //////////////////////////
 *`GIT_LITERAL_PATHSPECS`* disables both of the above behaviors; no wildcard characters will work, and the override prefixes are disabled as well.

--- a/book/A-git-in-other-environments/sections/powershell.asc
+++ b/book/A-git-in-other-environments/sections/powershell.asc
@@ -53,11 +53,14 @@ PowerShell의 ExecutionPolicy에 대한 자세한 내용은 https://docs.microso
 ===== PowerShell 갤러리로 설치
 
 //////////////////////////
-If you have at least PowerShell 5 or PowerShell 4 with PackageManagement installed, you can use the package manager to fetch Posh-Git for you.
-More information about the requirements: (https://docs.microsoft.com/en-us/powershell/gallery/psget/get_psget_module[])
+If you have at least PowerShell 5 or PowerShell 4 with PackageManagement installed, you can use the package manager to install posh-git for you.
+
+More information about PowerShell Gallery: https://docs.microsoft.com/en-us/powershell/scripting/gallery/overview[].
 //////////////////////////
-PowerShell 버전 5 이상을 사용하거나 PowerShell 4를 PackageManagement 모듈(Cmdlets)을 설치해서 사용한다면 패키지 관리자를 통해서 Posh-Git을 가져올 수 있다.
-자세한 요구사항은 https://docs.microsoft.com/en-us/powershell/gallery/psget/get_psget_module[] 에서 확인할 수 있다.
+PowerShell 버전 5 이상을 사용하거나 PowerShell 4를 PackageManagement 모듈(Cmdlets)을 설치해서 사용한다면 패키지 관리자를 통해서 Posh-Git을 설치할 수 있다.
+
+자세한 요구사항은 https://docs.microsoft.com/en-us/powershell/scripting/gallery/overview[] 에서 확인할 수 있다.
+
 [source,powershell]
 -----
 > Set-PSRepository -Name PSGallery -InstallationPolicy Trusted
@@ -66,7 +69,7 @@ PowerShell 버전 5 이상을 사용하거나 PowerShell 4를 PackageManagement 
 -----
 
 //////////////////////////
-If you want to install Posh-Git only for the current user and not globally, use "-Scope CurrentUser" instead. 
+If you want to install Posh-Git only for the current user and not globally, use "-Scope CurrentUser" instead.
 If the second command fails with an error like `Module 'PowerShellGet' was not installed by using Install-Module`, you'll need to run another command first:
 //////////////////////////
 Posh-Git을 설치할 모든 사용자에 설치하지 않도 자신만 사용하게 "-Scope CurrentUser" 옵션을 적용한다.

--- a/book/B-embedding-git/sections/jgit.asc
+++ b/book/B-embedding-git/sections/jgit.asc
@@ -249,13 +249,11 @@ If you're interested and want to learn more, here's where to look for informatio
 자세히 알고 싶다면 아래 링크에서 도움받을 수 있다.
 
 //////////////////////////
-* The official JGit API documentation can be found at http://www.eclipse.org/jgit/documentation/[].
+* The official JGit API documentation can be found at https://www.eclipse.org/jgit/documentation[].
   These are standard Javadoc, so your favorite JVM IDE will be able to install them locally, as well.
 * The JGit Cookbook at https://github.com/centic9/jgit-cookbook[] has many examples of how to do specific tasks with JGit.
-* There are several good resources pointed out at http://stackoverflow.com/questions/6861881[].
 //////////////////////////
-* 공식 JGit API 문서: http://download.eclipse.org/jgit/docs/latest/apidocs[]
+* 공식 JGit API 문서: https://www.eclipse.org/jgit/documentation[]
   표준 Javadoc 문서로 즐겨 쓰는 JVM IDE에 추가할 수 있다.
 * JGit Cookbook: https://github.com/centic9/jgit-cookbook[]
   JGit으로 무엇을 할 수 있는지 보여주는 예제가 많다.
-* StackOverflow에서도 도움이 되는 자료가 많다: http://stackoverflow.com/questions/6861881[]


### PR DESCRIPTION
**원인**

[https://github.com/progit/progit2-ko/issues/121](https://github.com/progit/progit2-ko/issues/121) 에서 발생한 action 빌드 오류 처리

오류: [https://github.com/progit/progit2-ko/actions/runs/1053350094](https://github.com/progit/progit2-ko/actions/runs/1053350094)

**github의 action이랑 현재 빌드하는게 좀 다른가?**

"release-on-merge.yml" 추가되면서 각 repository의 rakefile 이용해서 빌드 하는 것이 아니라 중앙 집중식으로 build 스크립트를 관리하고 있다.

- [https://raw.githubusercontent.com/progit/progit2-pub/master/bootstrap.sh](https://raw.githubusercontent.com/progit/progit2-pub/master/bootstrap.sh)
- [https://raw.githubusercontent.com/progit/progit2-pub/master/Gemfile](https://raw.githubusercontent.com/progit/progit2-pub/master/Gemfile)
- [https://raw.githubusercontent.com/progit/progit2-pub/master/Rakefile](https://raw.githubusercontent.com/progit/progit2-pub/master/Rakefile)

**새 rake 파일의 htmlproofer 에서 오류**

더 깐깐하게 html을 체크하기에 문법 오류를 일부 고쳐서 merge 한다.

**epubcheck: Failed to execute epubcheck. 오류**

현재 progit2-ko의 dockerfile로 생성한 container에서 epubcheck(epubcheck-ruby)의 실행이 잘 되지 않는다. 관련 dependency가 없는 것인가?

epubcheck-ruby는 epubcheck(java)를 wrapping하는 라이브러리. 따라서 java 필요함. apt-get install -y openjdk-8-jre