### PR TITLE
Update changed links

### DIFF
--- a/book/01-introduction/sections/installing.asc
+++ b/book/01-introduction/sections/installing.asc
@@ -173,9 +173,9 @@ $ sudo apt-get install dh-autoreconf libcurl4-gnutls-dev libexpat1-dev \
 
 //////////////////////////
 In order to be able to add the documentation in various formats (doc, html, info), these additional dependencies are required:
-In order to be able to add the documentation in various formats (doc, html, info), these additional dependencies are required (Note: users of RHEL and RHEL-derivatives like CentOS and Scientific Linux will have to https://fedoraproject.org/wiki/EPEL#How_can_I_use_these_extra_packages.3F[enable the EPEL repository] to download the `docbook2X` package):
+In order to be able to add the documentation in various formats (doc, html, info), these additional dependencies are required (Note: users of RHEL and RHEL-derivatives like CentOS and Scientific Linux will have to https://docs.fedoraproject.org/en-US/epel/#how_can_i_use_these_extra_packages[enable the EPEL repository] to download the `docbook2X` package):
 //////////////////////////
-문서를 다양한(doc, html, info) 형식으로 추가하려면 다음의 패키지들이 추가로 필요하다(주의: CentOS나 Scientific Linux 같은 RHEL 계열 사용자는 https://fedoraproject.org/wiki/EPEL#How_can_I_use_these_extra_packages.3F[EPEL 저장소를 켜고] `docbook2X` 패키지를 다운로드해야 한다.)
+문서를 다양한(doc, html, info) 형식으로 추가하려면 다음의 패키지들이 추가로 필요하다(주의: CentOS나 Scientific Linux 같은 RHEL 계열 사용자는 https://docs.fedoraproject.org/en-US/epel/#how_can_i_use_these_extra_packages[EPEL 저장소를 켜고] `docbook2X` 패키지를 다운로드해야 한다.)
 
 [source,console]
 ----

--- a/book/A-git-in-other-environments/sections/visualstudio.asc
+++ b/book/A-git-in-other-environments/sections/visualstudio.asc
@@ -49,8 +49,6 @@ image::images/vs-2.png[Visual Studio의 Git 센터 Home 뷰.]
 //////////////////////////
 Visual Studio now has a powerful task-focused UI for Git.
 It includes a linear history view, a diff viewer, remote commands, and many other capabilities.
-For complete documentation of this feature (which doesn't fit here), go to http://msdn.microsoft.com/en-us/library/hh850437.aspx[].
 //////////////////////////
 Visual Studio에는 Git과 연동되는 Task-focused UI도 있다.
 여기에는 히스토리 뷰, Diff 뷰어, 리모트 명령어 등등의 기능이 포함된다.
-이 기능에 대한 자세한 문서는 http://msdn.microsoft.com/en-us/library/hh850437.aspx[]에 있다.


### PR DESCRIPTION
CI 단계에서 사용되는 progit/progit2-pub 레포지토리의 파일이 변경되면서 릴리즈가 실패하는 현상이 발생되는 것 같습니다.
HTMLProofer 설정 변경으로 해결할 수 있는 건들은 [progit2-pub](https://github.com/progit/progit2-pub/pull/13) 레포지토리에서 수정을 하였고, 나머지 건들은 `installing.asc` 파일은 링크를 수정하고 `visualstudio.asc` 파일은 아예 없어진 페이지라서 해당 라인 삭제하는 것으로 처리하였습니다.

로컬에서 테스트 시 정상 빌드 되는 것으로 보입니다.