### PR TITLE
Fix concurrency issues in release

### DIFF
--- a/.github/workflows/release-on-merge.yml
+++ b/.github/workflows/release-on-merge.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches: [ main, master ]
 
+concurrency: release
+
 jobs:
   release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
- release 시 실행되는 GitHub Action의 순서가 `이전 태그값을 구해서 1을 더한 값으로 새 태그값 계산` -> `빌드` -> `앞에서 구한 태그값으로 release`로 되어있기 때문에 master 브랜치에 생긴 새 커밋의 액션이 끝나지 않은 상태로 새로운 커밋이 생겨서 CI가 또 돌 경우, 두번째 커밋이 빌드가 성공해도 릴리즈가 실패하는 현상이 있습니다.
- atomic하게 이전 태그를 기반으로 새 태그를 계산하고 릴리즈하는 API는 아직 없는 것 같습니다. 마스터 브랜치에서 동시에 여러 액션이 돌 일이 없을 것 같기도 하고, 앞에서 설명한대로 (태그 계산 방식을 바꾸지 않는 이상) 동시에 돌면 안될 것 같기 때문에 concurrency 옵션을 추가했습니다.
- 참고: https://github.com/progit/progit2-ko/actions/runs/3924407747/jobs/6708646550
![image](https://user-images.githubusercontent.com/16630665/215272799-aded6392-d3cb-4e6f-b1d6-8ee6008391c3.png)
